### PR TITLE
Work-a-round if a Huey worker died

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,11 +82,11 @@ logs: ## Display and follow docker logs
 
 reload_django: ## Reload the Django dev server
 	./compose.sh exec django /django/docker/utils/kill_python.sh
-	$(MAKE) logs
+	./compose.sh logs --tail=500 --follow django
 
 reload_huey: ## Reload the Huey worker
 	./compose.sh exec huey /django/docker/utils/kill_python.sh
-	$(MAKE) logs
+	./compose.sh logs --tail=500 --follow django huey
 
 restart: down up  ## Restart the containers
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
         build:
             context: .
             dockerfile: docker/django/Dockerfile
+        deploy:
+            resources:
+                limits:
+                    cpus: '0.50'
+                    memory: 100M
         restart: "no"
         hostname: huey
         env_file: ./docker/common.env

--- a/docker/huey/entrypoint.sh
+++ b/docker/huey/entrypoint.sh
@@ -26,7 +26,7 @@ echo "$(date +%c) - ${0} $*"
     # install/update venv and wait for services:
     /django/docker/utils/init.sh "${1}"
 
-    poetry run ./manage.py run_huey
+    poetry run ./manage.py run_huey --worker-type process --workers 2
     echo "Huey terminated with exit code: $?"
     sleep 3
     exit 1

--- a/huey_monitor/__init__.py
+++ b/huey_monitor/__init__.py
@@ -2,4 +2,4 @@
     Huey Monitor Django reuseable App
 """
 default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
-__version__ = '0.0.3'
+__version__ = '0.0.4'

--- a/huey_monitor/tasks.py
+++ b/huey_monitor/tasks.py
@@ -1,10 +1,14 @@
+import logging
 import sys
 import traceback
 import uuid
 
-from huey.contrib.djhuey import signal
+from huey.contrib.djhuey import on_startup, signal
 
 from huey_monitor.models import SignalInfoModel, TaskModel
+
+
+logger = logging.getLogger(__name__)
 
 
 @signal()
@@ -13,6 +17,7 @@ def store_signals(signal, task, exc=None):
     Store all Huey signals.
     """
     task_id = uuid.UUID(task.id)
+    logger.info('Store Task %s signal %r', task_id, signal)
 
     task_model_instance, created = TaskModel.objects.get_or_create(
         task_id=task_id,
@@ -34,3 +39,30 @@ def store_signals(signal, task, exc=None):
 
     task_model_instance.state_id = last_signal.pk
     task_model_instance.save(update_fields=('state_id',))
+
+
+@on_startup()
+def startup_handler():
+    """
+    "Change" task state to "unknown" on startup for every "executing" tasks.
+
+    The problem:
+    We get no signal if the Huey worker died (e.g.: memory error)
+    To remove the "executing" state of tasks: Just add a pseudo signal entry to it.
+
+    Note: This will add a "unknown" state to other task, that are not affected from
+    the died worker :(
+
+    See also: https://github.com/coleifer/huey/issues/569
+    """
+    logger.debug('startup handler called')
+
+    qs = TaskModel.objects.filter(state__signal_name='executing')
+    for task_model_instance in qs:
+        logger.info('Mark "executing" task %s to "unknown"', task_model_instance.pk)
+        last_signal = SignalInfoModel.objects.create(
+            task_id=task_model_instance.pk,
+            signal_name='unknown',
+        )
+        task_model_instance.state_id = last_signal.pk
+        task_model_instance.save(update_fields=('state_id',))

--- a/huey_monitor_tests/test_app/management/commands/fire_test_tasks.py
+++ b/huey_monitor_tests/test_app/management/commands/fire_test_tasks.py
@@ -1,6 +1,8 @@
+from pathlib import Path
+
 from django.core.management import BaseCommand
 
-from huey_monitor_tests.test_app.tasks import delay_task, raise_error_task, retry_and_lock_task
+from huey_monitor_tests.test_app.tasks import delay_task, out_of_memory_task, raise_error_task, retry_and_lock_task
 
 
 class Command(BaseCommand):
@@ -13,6 +15,11 @@ class Command(BaseCommand):
             msg='test type error exception'
         )
         retry_and_lock_task(info='1', sleep=5)
+
+        if Path('/.dockerenv').exists():
+            out_of_memory_task()
+        else:
+            print('Skip out of memory task outside docker container ;)')
 
         delay_task(name='test sleep 10', sleep=10)
         raise_error_task(

--- a/huey_monitor_tests/test_app/tasks.py
+++ b/huey_monitor_tests/test_app/tasks.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import time
 
 from huey import crontab
@@ -33,3 +34,13 @@ def retry_and_lock_task(info='<no-info>', sleep=3):
     logger.info('Start "retry_and_lock_task" - %r - sleep %s Sec.', info, sleep)
     time.sleep(sleep)
     raise RuntimeError(f'{info!r} error after {sleep} sec. sleep')
+
+
+@task(retries=1)  # Retry the task one time
+def out_of_memory_task():
+    logger.warning('Start out of memory task !')
+    obj = ['X']
+    while True:
+        obj = obj * 2
+        size = sys.getsizeof(obj)
+        logger.warning('OOM size: %s', size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-huey-monitor"
-version = "0.0.3"
+version = "0.0.4"
 description = "Django based tool for monitoring huey task queue: https://github.com/coleifer/huey"
 authors = ["JensDiemer <git@jensdiemer.de>"]
 packages = [


### PR DESCRIPTION
"Change" task state to "unknown" on startup for every "executing" tasks.

The problem:
We get no signal if the Huey worker died (e.g.: memory error)
To remove the "executing" state of tasks: Just add a pseudo signal entry to it.

Note: This will add a "unknown" state to other task, that are not affected from
the diet worker :(

See also: https://github.com/coleifer/huey/issues/569

additional changes:

* Limit the huey worker RAM in test project
* add `out_of_memory_task()` and fire it with the other example tasks