### PR TITLE
Fix missing colors in Huey logs

### DIFF
--- a/huey_monitor_tests/test_project/settings/base.py
+++ b/huey_monitor_tests/test_project/settings/base.py
@@ -123,6 +123,7 @@ LOGGING = {
         'django.auth': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
         'django.security': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
         'django.request': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
+        'huey': {'handlers': ['console'], 'level': 'INFO', 'propagate': False},
         'huey_monitor': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
         'huey_monitor_tests': {'handlers': ['console'], 'level': 'DEBUG', 'propagate': False},
     },


### PR DESCRIPTION
We just need to setup `huey` logging to get colors for Huey log output, too.

The Huey consumer activate logging for himself if his log is not setup. This is the reason why it did not change anything at https://github.com/boxine/django-huey-monitor/pull/9 ;)