### PR TITLE
Update README by adding 'bx_py_utils' to INSTALLED_APPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install django-huey-monitor
 ```python
 INSTALLED_APPS = [
     #...
+    'bx_py_utils', # https://github.com/boxine/bx_py_utils
     'huey_monitor',
     #...
 ]


### PR DESCRIPTION
Missing `bx_py_utils` cause: `'humanize_time' is not a registered tag library.`

See: https://github.com/boxine/django-huey-monitor/issues/21