### PR TITLE
Modernize github CI pipeline and bugfix local `tox` call

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,4 +1,4 @@
-name: test
+name: Test
 
 on:
   schedule:
@@ -7,15 +7,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: '${{ matrix.os }} Python ${{ matrix.python-version }} Django ${{ matrix.django }}'
+    runs-on: ${{ matrix.os }}
+    env:
+      PYTHONUNBUFFERED: 1
     strategy:
-      max-parallel: 2
+      fail-fast: false
       matrix:
+        os: [ubuntu-latest, macOS-latest] # TODO: windows-latest
         python-version: [3.9, 3.8, 3.7]
+        django: [2.2, 3.1, 3.2]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: 'Set up Python ${{ matrix.python-version }}'
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: '${{ matrix.python-version }}'
 
@@ -25,7 +30,6 @@ jobs:
         poetry lock
         poetry show --tree
         make install
-        pip3 install tox-gh-actions
 
     - name: 'List installed packages'
       run: |
@@ -35,9 +39,11 @@ jobs:
       run: |
         make tox-listenvs
 
-    - name: 'Run tests with Python v${{ matrix.python-version }}'
+    - name: 'Run tests on ${{ matrix.os }} with Python ${{ matrix.python-version }} Django ${{ matrix.django }}'
       run: |
-        make tox
+        poetry run tox -e python-django${{ matrix.django }}
+      env:
+        PYTEST_ADDOPTS: "-c pytest-ci.ini"
 
     - name: 'Upload coverage report'
       run: bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,20 @@ without docker:
 ~/django-huey-monitor$ ./manage.sh run_testserver
 ```
 
+
 ## Backwards-incompatible changes
+
+
+### Version compatibility
+
+|= huey-monitor   |= Django          |= Python
+| >v0.5.0         | v2.2, v3.1, v3.2 | v3.7, v3.8, v3.9
+| <=v0.4.0        | v2.2, v3.0, v3.1 | v3.7, v3.8, v3.9
+
+
+### v0.5.0
+
+Change CI and remove tests against Django 3.0, but add test run with Django v3.2
 
 ### v0.3.0 -> v0.4.0 - Outsourcing Django stuff
 
@@ -170,9 +183,12 @@ You must change your Django settings and replace the app name:
  ]
 ```
 
+
 ## History
 
 * [dev](https://github.com/boxine/django-huey-monitor/compare/v0.4.0...master)
+  * Remove test against Django 3.0 and add tests with Django 3.2
+  * Bugfix local `tox` runs and use different Python versions
   * _tbc_
 * [v0.4.0 - 21.05.2020](https://github.com/boxine/django-huey-monitor/compare/v0.3.0...v0.4.0)
   * bx_py_utils was split and Django related stuff moved into: https://github.com/boxine/bx_django_utils

--- a/huey_monitor_tests/tests/test_huey_monitor.py
+++ b/huey_monitor_tests/tests/test_huey_monitor.py
@@ -1,4 +1,5 @@
 from bx_django_utils.test_utils.html_assertion import HtmlAssertionMixin
+from django import VERSION as DJANGO_VERSION
 from django.contrib.auth.models import User
 from django.test import TestCase
 
@@ -42,8 +43,13 @@ class HueyMonitorTestCase(HtmlAssertionMixin, TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         self.assertTemplateUsed(response, 'admin/change_form.html')
+
+        title = 'View Task | Django site admin'
+        if DJANGO_VERSION >= (3, 2):
+            title = f'delay_task: complete (Main task) | {title}'
+
         self.assert_html_parts(response, parts=(
-            '<title>delay_task: complete (Main task) | View Task | Django site admin</title>',
+            f'<title>{title}</title>',
 
             '<div class="readonly">delay_task</div>',
 
@@ -78,12 +84,13 @@ class HueyMonitorTestCase(HtmlAssertionMixin, TestCase):
         response = self.client.get(url)
         assert response.status_code == 200
         self.assertTemplateUsed(response, 'admin/change_form.html')
+
+        title = 'View Task Signal | Django site admin'
+        if DJANGO_VERSION >= (3, 2):
+            title = f'error - This is a test exception | {title}'
+
         self.assert_html_parts(response, parts=(
-            (
-                '<title>'
-                'error - This is a test exception | View Task Signal | Django site admin'
-                '</title>'
-            ),
+            f'<title>{title}</title>',
 
             '<div class="readonly">error</div>',
             '<div class="readonly">This is a test exception</div>',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ flake8 = "*"
 flynt = "*"
 autopep8 = "*"
 pyupgrade = "*"
+tox-poetry-installer = {extras = ["poetry"], version = "*"}  # https://github.com/enpaul/tox-poetry-installer
 
 [tool.poetry.scripts]
 publish = "huey_monitor_tests.test_project.publish:publish"
@@ -87,12 +88,14 @@ default_section="THIRDPARTY"
 sections=["FUTURE","STDLIB","THIRDPARTY","FIRSTPARTY","LOCALFOLDER"]
 lines_after_imports=2
 
+[tool.coverage.run]
+omit=[".*"]
 
 [tool.pytest.ini_options]
 # https://docs.pytest.org/en/latest/customize.html#pyproject-toml
 minversion = "6.0"
 DJANGO_SETTINGS_MODULE="huey_monitor_tests.test_project.settings.tests"
-norecursedirs = ".* .git __pycache__ coverage* dist htmlcov volumes"
+norecursedirs = ".* __pycache__ coverage* dist htmlcov volumes"
 # sometimes helpfull "addopts" arguments:
 #    -vv
 #    --verbose
@@ -123,17 +126,19 @@ addopts = """
 legacy_tox_ini = """
 [tox]
 isolated_build = True
-envlist = py39-django{2.2,3.0,3.1},py38-django{2.2,3.0,3.1},py37-django{2.2,3.0,3.1}
+envlist = py{37,38,39}-django{2.2,3.1,3.2}
 skip_missing_interpreters = True
 
 [testenv]
 passenv = *
-whitelist_externals = pytest
+whitelist_externals = make
 deps =
-    django2.2: django~=2.2.0
-    django3.0: django~=3.0.0
-    django3.1: django~=3.1.0
+    django2.2: django>=2.2,<2.3
+    django3.1: django>=3.1,<3.2
+    django3.2: django>=3.2,<3.3
+install_dev_deps=True
 commands =
+    python --version
     django-admin --version
-    pytest
+    python -m pytest
 """

--- a/pytest-ci.ini
+++ b/pytest-ci.ini
@@ -1,0 +1,33 @@
+#
+# pytest config used in CI pipeline
+# manual usage, e.g:
+#
+#   $ pipenv run pytest -c pytest-ci.ini
+#
+# http://doc.pytest.org/en/latest/customize.html#builtin-configuration-file-options
+# https://pytest-django.readthedocs.io/en/latest/
+
+[pytest]
+testpaths = .
+norecursedirs = .* __pycache__ coverage* dist htmlcov volumes
+
+# Use postgres database for tests:
+DJANGO_SETTINGS_MODULE = huey_monitor_tests.test_project.settings.tests
+
+addopts =
+    # reuse existing database, but apply migrations:
+    --create-db
+    --migrations
+
+    # coverage:
+    --cov=.
+    --no-cov-on-fail
+
+    --showlocals
+    --doctest-modules
+
+    # exit after 5 failures:
+    --maxfail=5
+
+    # per-test capturing method: one of fd|sys|no:
+    --capture=no


### PR DESCRIPTION
Before this PR the CI steps doesn't run only one combination.

e.g.: https://github.com/boxine/django-huey-monitor/runs/2711496007

Now all Github CI action steps runs on one Python/Django version combination.

Another problem: Call `tox` local will not use different Python versions!

* Remove test against Django 3.0 and add tests with Django 3.2
* Run tests also on MacOS
* Add a `pytest-ci.ini` that will only used on github CI
* Omit `.*` in coverage