### PR TITLE
Suppress the default_app_config attribute in Django 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ You must change your Django settings and replace the app name:
 
 * [dev](https://github.com/boxine/django-huey-monitor/compare/v0.4.1...master)
   * _tbc_
+* [v0.4.2 - 12.07.2021](https://github.com/boxine/django-huey-monitor/compare/v0.4.1...v0.4.2)
+  * suppress the default_app_config attribute in Django 3.2+
 * [v0.4.1 - 02.06.2020](https://github.com/boxine/django-huey-monitor/compare/v0.4.0...v0.4.1)
   * Bugfix `ProcessInfo.__str__()`
   * [#27](https://github.com/boxine/django-huey-monitor/issues/27) Check 'desc' length in `ProcessInfo`

--- a/huey_monitor/__init__.py
+++ b/huey_monitor/__init__.py
@@ -1,5 +1,8 @@
 """
     Huey Monitor Django reuseable App
 """
-default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
-__version__ = '0.4.1'
+from django import VERSION as DJANGO_VERSION
+
+if DJANGO_VERSION < (3, 2):
+    default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
+__version__ = '0.4.2'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-huey-monitor"
-version = "0.4.1"
+version = "0.4.2"
 description = "Django based tool for monitoring huey task queue: https://github.com/coleifer/huey"
 authors = ["JensDiemer <git@jensdiemer.de>"]
 packages = [


### PR DESCRIPTION
Gets rid of the warning:

```
django.utils.deprecation.RemovedInDjango41Warning: 'huey_monitor' defines default_app_config = 'huey_monitor.apps.HueyMonitorConfig'. Django now detects this configuration automatically. You can remove default_app_config.
```