### PR TITLE
suppress the default_app_config attribute in Django 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ You must change your Django settings and replace the app name:
 ## History
 
 * [dev](https://github.com/boxine/django-huey-monitor/compare/v0.4.1...master)
+  * suppress the default_app_config attribute in Django 3.2+ (contributed by [Jonas Svarvaa](https://github.com/xolan))
   * _tbc_
 * [v0.4.1 - 02.06.2020](https://github.com/boxine/django-huey-monitor/compare/v0.4.0...v0.4.1)
   * Bugfix `ProcessInfo.__str__()`

--- a/huey_monitor/__init__.py
+++ b/huey_monitor/__init__.py
@@ -1,5 +1,12 @@
 """
     Huey Monitor Django reuseable App
 """
-default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
+
+from django import VERSION as DJANGO_VERSION
+
+
+if DJANGO_VERSION < (3, 2):
+    default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
+
+
 __version__ = '0.4.1'


### PR DESCRIPTION
Refactored version from https://github.com/boxine/django-huey-monitor/pull/41 that didn't prepare a
new release ;)