### PR TITLE
throughput formating for rate<1

### DIFF
--- a/huey_monitor/humanize.py
+++ b/huey_monitor/humanize.py
@@ -37,6 +37,34 @@ def format_sizeof(num, suffix='', divisor=1000):
 
     return f'{num:3.1f}Y' + suffix
 
+def format_duration(num):
+    """
+    Formats a number of seconds into s, min, h or days depending on the duration.
+
+    >>> format_duration(15.525)
+    '15.5 s'
+    >>> format_duration(115.565)
+    '1.9 min'
+    >>> format_duration(11115.565)
+    '3.1 h'
+    >>> format_duration(1111005.565)
+    '12.9 days'
+
+    Returns
+    -------
+    out  : str
+
+    """
+    if abs(num)<60:
+        return f'{num:1.1f} s'
+    elif abs(num)<60*60:
+        return f'{num/60:1.1f} min'
+    elif abs(num)<60*60*24:
+        return f'{num/3600:1.1f} h'
+    else:
+        return f'{num/3600/24:1.1f} days'
+
+
 
 def percentage(num, total):
     """
@@ -52,11 +80,21 @@ def percentage(num, total):
 
 def throughput(num, elapsed_sec, suffix='', divisor=1000):
     """
+    Returns throughput in different format depending if rate is higher or lower than 1
+    
     >>> throughput(3.333, 1)
     '3.33/s'
     >>> throughput(2048, 1, suffix='Bytes', divisor=1024)
     '2.00kBytes/s'
+    >>> throughput(4, 250, suffix='subtask')
+    '1.1 min/subtask '
     """
     rate = num / elapsed_sec
-    rate_str = format_sizeof(rate, suffix=suffix, divisor=divisor)
-    return f'{rate_str}/s'
+    
+    if rate > 1:
+        rate_str = format_sizeof(rate, suffix=suffix, divisor=divisor)
+        return f'{rate_str}/s'
+
+    else:
+        duration_str = format_duration(1/rate)
+        return f'{duration_str}/{suffix}'


### PR DESCRIPTION
throughput in different format depending if rate is higher or lower than 1

Hi, for throughputs which are below 1, and especially a lot below 1, the humanized throughput is not very informative and not obvious to interpret for human brain:
![image](https://user-images.githubusercontent.com/50452683/131094103-32edab1d-3bed-45bc-b033-7110da860c01.png)
 
![image](https://user-images.githubusercontent.com/50452683/131094505-75f70750-11c1-4373-9d1e-342ba8499c6a.png)

I propose for rates <1 to change the `humanize.throughput` function to display in this case duration / unit.

In my case: `5.3 s/typology` (instead of `0.19 typology/s`) and `1.9 days/piece` (instead of `0.00 piece/s`)