### PR TITLE
Add temporary `cumulate2parents` flag to `ProcessInfo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,8 +187,10 @@ You must change your Django settings and replace the app name:
 
 ## History
 
-* [dev](https://github.com/boxine/django-huey-monitor/compare/v0.4.1...master)
+* [dev](https://github.com/boxine/django-huey-monitor/compare/v0.4.3...master)
   * _tbc_
+* [v0.4.3 - 07.01.2022](https://github.com/boxine/django-huey-monitor/compare/v0.4.2...v0.4.3)
+  * Add temporary `cumulate2parents` flag to `ProcessInfo` ([contributed by formacube](https://github.com/boxine/django-huey-monitor/pull/44))
 * [v0.4.2 - 25.08.2020](https://github.com/boxine/django-huey-monitor/compare/v0.4.1...v0.4.2)
   * suppress the default_app_config attribute in Django 3.2+ (contributed by [Jonas Svarvaa](https://github.com/xolan))
 * [v0.4.1 - 02.06.2020](https://github.com/boxine/django-huey-monitor/compare/v0.4.0...v0.4.1)

--- a/huey_monitor/__init__.py
+++ b/huey_monitor/__init__.py
@@ -9,4 +9,4 @@ if DJANGO_VERSION < (3, 2):
     default_app_config = 'huey_monitor.apps.HueyMonitorConfig'
 
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-huey-monitor"
-version = "0.4.2"
+version = "0.4.3"
 description = "Django based tool for monitoring huey task queue: https://github.com/coleifer/huey"
 authors = ["JensDiemer <git@jensdiemer.de>"]
 packages = [


### PR DESCRIPTION
Use the code from https://github.com/boxine/django-huey-monitor/pull/44 but without the big README
change, because `cumulate2parents` is already deprecated when it is introduced, see:
* https://github.com/boxine/django-huey-monitor/discussions/60?converting=1#discussioncomment-1924721
* https://github.com/boxine/django-huey-monitor/pull/58