### PR TITLE
#70 showing task description when available on TaskAdmin

### DIFF
--- a/huey_monitor/admin.py
+++ b/huey_monitor/admin.py
@@ -82,6 +82,7 @@ class TaskModelAdmin(admin.ModelAdmin):
         'human_update_dt',
         'column_name',
         'state',
+        'name',
         'total',
         'human_unit',
         'human_percentage',
@@ -97,6 +98,7 @@ class TaskModelAdmin(admin.ModelAdmin):
     )
     ordering = ('-update_dt',)
     list_display_links = None
+    list_select_related = ('state',)
     date_hierarchy = 'create_dt'
     list_filter = ('state__hostname', 'name', 'state__signal_name')
     search_fields = ('name', 'state__exception_line', 'state__exception')
@@ -110,6 +112,7 @@ class TaskModelAdmin(admin.ModelAdmin):
         (_('Task Information'), {
             'fields': (
                 'name',
+                'desc',
                 'state',
                 'human_progress_string',
                 'signals'

--- a/huey_monitor/templates/admin/huey_monitor/taskmodel/column_name.html
+++ b/huey_monitor/templates/admin/huey_monitor/taskmodel/column_name.html
@@ -1,10 +1,10 @@
 
-<strong><a href="{{ main_task.admin_link }}">{{ main_task.name }}</a></strong>
+<strong><a href="{{ main_task.admin_link }}">{% firstof main_task.desc main_task.name %}</a></strong>
 {% if sub_tasks %}
 <ul style="white-space: nowrap;">
     {% for sub_task in sub_tasks %}
         <li>
-            <a href="{{ sub_task.admin_link }}">{{ sub_task.name }}</a>
+            <a href="{{ sub_task.admin_link }}">{% firstof sub_task.desc sub_task.name %}</a>
             {{ sub_task.state|default_if_none:"-"|truncatechars:40 }}
             {{ sub_task.human_progress_string }}
         </li>

--- a/huey_monitor/templates/admin/huey_monitor/taskmodel/task_hierarchy_info.html
+++ b/huey_monitor/templates/admin/huey_monitor/taskmodel/task_hierarchy_info.html
@@ -2,7 +2,7 @@
 
 {% if main_task %}
 <p>
-    <a href="{{ main_task.admin_link }}">{{ main_task.name }}</a>
+    <a href="{{ main_task.admin_link }}">{% firstof main_task.desc main_task.name %}</a>
     {{ main_task.state|default_if_none:"" }}
     {{ main_task.human_progress_string }}
 </p>
@@ -24,7 +24,7 @@
     {% for sub_task in sub_tasks %}
         <tr>
             <td>
-                <a href="{{ sub_task.admin_link }}">{{ sub_task.name }}</a>
+                <a href="{{ sub_task.admin_link }}">{% firstof sub_task.desc sub_task.name %}</a>
             </td>
             <td>{{ sub_task.state|default_if_none:"-" }}</td>
             <td>{{ sub_task.human_progress_string }}</td>


### PR DESCRIPTION
As stated on issue #70, allows to use Task description to easily identify between tasks when looking at TaskAdmin listview and changeviews - snapshots availlable in issue #70 