### PR TITLE
Remove seperate linting step in github actions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -55,8 +55,3 @@ jobs:
 
     - name: 'Upload coverage report'
       run: bash <(curl -s https://codecov.io/bash)
-
-    - name: 'Run linters'
-      if: matrix.python-version == '3.8'
-      run: |
-        make lint


### PR DESCRIPTION
There is no need to test linting separately, because this is done in pytest run since:
https://github.com/boxine/django-huey-monitor/pull/74