### PR TITLE
Always show django debug toolbar in test project

### DIFF
--- a/huey_monitor_tests/test_project/settings/docker.py
+++ b/huey_monitor_tests/test_project/settings/docker.py
@@ -23,3 +23,17 @@ DATABASES = {
         'CONN_MAX_AGE': 600,
     },
 }
+
+
+# Django debug toolbar
+
+
+def always_show_toolbar(request):
+    return True
+
+
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_COLLAPSED': True,
+    'SHOW_TEMPLATE_CONTEXT': True,
+    'SHOW_TOOLBAR_CALLBACK': always_show_toolbar,
+}


### PR DESCRIPTION
The test project runs in docker container. So the `REMOTE_ADDR` is some kind of random and it's not
easy to add this dynamic IP into `INTERNAL_IPS`. Just always enable the debug toolbar ;)