### PR TITLE
ordering Sub-tasks chronologically in admin

### DIFF
--- a/huey_monitor/models.py
+++ b/huey_monitor/models.py
@@ -197,6 +197,7 @@ class TaskModel(TimetrackingBaseModel):
     class Meta:
         verbose_name = _('Task')
         verbose_name_plural = _('Tasks')
+        ordering = ['-create_dt']
 
 
 class SignalInfoModel(models.Model):


### PR DESCRIPTION
When there are a number of sub tasks, they are currently displayed in a way that prevent to make sense of any kind of logic
Ordering them chronologically helps to identify problems in case something does not work as planned