### PR TITLE
Implementing task desc croping(cf #27)

### DIFF
--- a/huey_monitor/tqdm.py
+++ b/huey_monitor/tqdm.py
@@ -53,9 +53,9 @@ class ProcessInfo:
             # what's happen ;)
             logger.warning(
                 "Process info description '%(desc)r' has been cropped to maximum authorized value (%(max_length)r)",
-                params={'desc': self.desc, 'max_length': TASK_MODEL_DESC_MAX_LENGTH,},
-            self.desc = self.desc[:TASK_MODEL_DESC_MAX_LENGTH]
+                params={'desc': self.desc, 'max_length': TASK_MODEL_DESC_MAX_LENGTH,}
             )
+            self.desc = self.desc[:TASK_MODEL_DESC_MAX_LENGTH]
 
         TaskModel.objects.filter(task_id=task.id).update(
             desc=self.desc,

--- a/huey_monitor/tqdm.py
+++ b/huey_monitor/tqdm.py
@@ -51,9 +51,10 @@ class ProcessInfo:
             # We call .update() that will not validate the data, so a overlong
             # description will raise a database error and maybe a user doesn't know
             # what's happen ;)
-            raise ValidationError(
-                'Process info description overlong: %(desc)r',
-                params={'desc': self.desc},
+            logger.warning(
+                "Process info description '%(desc)r' has been cropped to maximum authorized value (%(max_length)r)",
+                params={'desc': self.desc, 'max_length': TASK_MODEL_DESC_MAX_LENGTH,},
+            self.desc = self.desc[:TASK_MODEL_DESC_MAX_LENGTH]
             )
 
         TaskModel.objects.filter(task_id=task.id).update(

--- a/huey_monitor/tqdm.py
+++ b/huey_monitor/tqdm.py
@@ -52,8 +52,8 @@ class ProcessInfo:
             # description will raise a database error and maybe a user doesn't know
             # what's happen ;)
             logger.warning(
-                "Process info description '%(desc)r' has been cropped to maximum authorized value (%(max_length)r)",
-                params={'desc': self.desc, 'max_length': TASK_MODEL_DESC_MAX_LENGTH,}
+                "Process info description %r has been cropped to maximum authorized value (%r)",
+                self.desc, TASK_MODEL_DESC_MAX_LENGTH
             )
             self.desc = self.desc[:TASK_MODEL_DESC_MAX_LENGTH]
 

--- a/huey_monitor_tests/tests/test_tqdm.py
+++ b/huey_monitor_tests/tests/test_tqdm.py
@@ -184,6 +184,14 @@ class ProcessInfoTestCase(TestCase):
         ]
 
         # Overlong description should be cut:
-        msg = f'["Process info description overlong: \'{overlong_txt}\'"]'
-        with self.assertRaisesMessage(ValidationError, msg):
+        with self.assertLogs('huey_monitor.tqdm') as logs:
             ProcessInfo(task, desc=overlong_txt, total=999)
+            instance = TaskModel.objects.get()
+            assert instance.desc == max_length_txt
+
+        assert logs.output == [
+            (
+                'INFO:huey_monitor.tqdm:Init TaskModel Task'
+                f' - {max_length_txt} 0/999 (divisor: 1000)'
+            )
+        ]

--- a/huey_monitor_tests/tests/test_tqdm.py
+++ b/huey_monitor_tests/tests/test_tqdm.py
@@ -167,6 +167,7 @@ class ProcessInfoTestCase(TestCase):
 
         max_length_txt = 'X' * max_length
         overlong_txt = 'Y' * (max_length + 1)
+        cropped_overlong_txt = 'Y' * max_length
 
         task = Task(id='00000000-0000-0000-0000-000000000001')
 
@@ -187,11 +188,11 @@ class ProcessInfoTestCase(TestCase):
         with self.assertLogs('huey_monitor.tqdm') as logs:
             ProcessInfo(task, desc=overlong_txt, total=999)
             instance = TaskModel.objects.get()
-            assert instance.desc == max_length_txt
+            assert instance.desc == cropped_overlong_txt
 
         assert logs.output == [
             (
                 'INFO:huey_monitor.tqdm:Init TaskModel Task'
-                f' - {max_length_txt} 0/999 (divisor: 1000)'
+                f' - {cropped_overlong_txt} 0/999 (divisor: 1000)'
             )
         ]


### PR DESCRIPTION
Coming back to #27,
I had in a middle of a long series of tasks one of them which crashed due to a `ValidationError('Process info description overlong')`.

It reminded me about #27 where I thought we implemented a crop of `TaskModel.desc` to 64 characters.

As stated already at the time, having a desc bigger than 64 char should not for me prevent a task to run.
Especially when task description are generated automatically

I would therefore suggest implementing the following changes