### PR TITLE
#91 display progression for on-going parent_tasks

### DIFF
--- a/huey_monitor/constants.py
+++ b/huey_monitor/constants.py
@@ -6,13 +6,16 @@ from huey import signals as _huey_signals
 # It does not mean that execution was successfully completed!
 #
 # Collect these Huey signals here:
-ENDED_HUEY_SIGNALS = (
+ISSUE_HUEY_SIGNALS = [
     _huey_signals.SIGNAL_CANCELED,
-    _huey_signals.SIGNAL_COMPLETE,
     _huey_signals.SIGNAL_ERROR,
     _huey_signals.SIGNAL_EXPIRED,
     _huey_signals.SIGNAL_REVOKED,
     _huey_signals.SIGNAL_INTERRUPTED,
-)
+]
+
+ENDED_HUEY_SIGNALS = ISSUE_HUEY_SIGNALS + [
+    _huey_signals.SIGNAL_COMPLETE,
+]
 
 TASK_MODEL_DESC_MAX_LENGTH = 128


### PR DESCRIPTION
Used for displaying parent_task progression in admin (cf #91)
when task is still on-going instead of just last signal