### PR TITLE
Delegating set_parent_task to ProcessInfo.__init__

### DIFF
--- a/huey_monitor/tqdm.py
+++ b/huey_monitor/tqdm.py
@@ -68,6 +68,12 @@ class ProcessInfo:
             cumulate_progress=cumulate2parents,
         )
 
+        if parent_task_id:
+            TaskModel.objects.set_parent_task(
+                main_task_id=parent_task_id,
+                sub_task_id=task.id,
+            )
+            
         self.total_progress = 0
 
         logger.info('Init TaskModel %s', self)

--- a/huey_monitor_tests/test_app/tasks.py
+++ b/huey_monitor_tests/test_app/tasks.py
@@ -87,15 +87,10 @@ def parallel_sub_task(task, parent_task_id, item_chunk, **info_kwargs):
     """
     Useless example: Just calculate the SHA256 hash from all files
     """
-    # Save relationship between the main and sub tasks:
-    TaskModel.objects.set_parent_task(
-        main_task_id=parent_task_id,
-        sub_task_id=task.id
-    )
-
     total_items = len(item_chunk)
 
-    # Init progress information of this sub task:
+    # Init progress information of this sub task
+    # and save relationship between the main and sub tasks:
     process_info = ProcessInfo(
         task, total=total_items, parent_task_id=parent_task_id, **info_kwargs
     )


### PR DESCRIPTION
Hi Jedie,

working a bit on the subtasks, I realized that currently, we have to link to `parent_task_id` two times:
first through the task code through the manager:
```        TaskModel.objects.set_parent_task(
            main_task_id=parent_task_id,
            sub_task_id=task.id,
        )
```

and second, we have to feed `ProcessInfo` with `parent_task_id`

I initially thought that within `ProcessInfo.__init__` we should read `parent_task_id` from the task.

Then I realized that, as `ProcessInfo.__init__` is anyway used to update fields from TaskModel,
 it should be better to keep the same logic, and allow `ProcessInfo.__init__` to generate the link between parent_task and sub_task if `parent_task_id` is provided.

That way, we gain a step, and the process of creating sub tasks is much easier (especially for new users).

And all previous implementations are still working the same (we just update the link between parent and sub task for nothing)