### PR TITLE
New: Display Huey pending/scheduled/result counts in admin

### DIFF
--- a/huey_monitor/templates/admin/huey_monitor/huey_counts_info.html
+++ b/huey_monitor/templates/admin/huey_monitor/huey_counts_info.html
@@ -1,0 +1,6 @@
+<p>
+    Huey counts:
+    Pending: {{ huey_pending_count }},
+    Scheduled: {{ huey_scheduled_count }},
+    Result: {{ huey_result_count }}
+</p>

--- a/huey_monitor/templates/admin/huey_monitor/taskmodel/change_list.html
+++ b/huey_monitor/templates/admin/huey_monitor/taskmodel/change_list.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_list.html" %}
+{% load huey_monitor %}
+
+{% block object-tools %}{{ block.super }}
+    {% huey_counts_info %}
+{% endblock %}

--- a/huey_monitor/templatetags/huey_monitor.py
+++ b/huey_monitor/templatetags/huey_monitor.py
@@ -1,0 +1,16 @@
+from django import template
+from django.template.loader import render_to_string
+from huey.contrib.djhuey import HUEY
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def huey_counts_info():
+    context = dict(
+        huey_pending_count=HUEY.pending_count(),
+        huey_scheduled_count=HUEY.scheduled_count(),
+        huey_result_count=HUEY.result_count(),
+    )
+    return render_to_string('admin/huey_monitor/huey_counts_info.html', context)

--- a/huey_monitor_project/tests/test_templatetags.py
+++ b/huey_monitor_project/tests/test_templatetags.py
@@ -1,0 +1,13 @@
+from unittest.mock import patch
+
+from django.test import SimpleTestCase
+from huey import MemoryHuey
+
+from huey_monitor.templatetags.huey_monitor import huey_counts_info
+
+
+class HueyMonitorTemplateTagsTestCase(SimpleTestCase):
+    def test_huey_counts_info(self):
+        with patch('huey_monitor.templatetags.huey_monitor.HUEY', MemoryHuey()):
+            html = huey_counts_info()
+        self.assertHTMLEqual(html, '<p>Huey counts: Pending: 0, Scheduled: 0, Result: 0</p>')


### PR DESCRIPTION
Looks like:
![grafik](https://github.com/boxine/django-huey-monitor/assets/71315/ca8018c4-86cf-42c1-96f2-d9de6eeb2bef)