### PR TITLE
Bugfix `ZeroDivisionError` in TaskModel admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,10 @@ You must change your Django settings and replace the app name:
 
 ## History
 
-* [dev](https://github.com/boxine/django-huey-monitor/compare/v0.8.0...main)
+* [dev](https://github.com/boxine/django-huey-monitor/compare/v0.8.1...main)
   * _tbc_
+* [v0.8.1 - 20.11.2023](https://github.com/boxine/django-huey-monitor/compare/v0.8.0...v0.8.1)
+  * Bugfix `ZeroDivisionError` in admin
 * [v0.8.0 - 20.11.2023](https://github.com/boxine/django-huey-monitor/compare/v0.7.1...v0.8.0)
   * Make is possible to override `list_filter` of `SignalInfoModelAdmin` and `TaskModelAdmin` via settings
   * Update local docker dev setup

--- a/huey_monitor/__init__.py
+++ b/huey_monitor/__init__.py
@@ -4,5 +4,5 @@
     Django based tool for monitoring huey task queue: https://github.com/coleifer/huey
 """
 
-__version__ = '0.8.0'
+__version__ = '0.8.1'
 __author__ = 'Jens Diemer <django-huey-monitor@jensdiemer.de>'

--- a/huey_monitor/humanize.py
+++ b/huey_monitor/humanize.py
@@ -41,13 +41,18 @@ def format_sizeof(num, suffix='', divisor=1000):
     return f'{num:3.1f}Y' + suffix
 
 
-def percentage(num, total):
+def percentage(num, total) -> str | None:
     """
     >>> percentage(25, 100)
     '25%'
     >>> percentage(33.333, 100)
     '33%'
+    >>> percentage(123, 0)
+    None
     """
+    if not total:
+        return None
+
     frac = num / total
     percentage = frac * 100
     return f'{percentage:.0f}%'

--- a/huey_monitor/models.py
+++ b/huey_monitor/models.py
@@ -120,7 +120,7 @@ class TaskModel(TimetrackingBaseModel):
             return dt_diff.total_seconds()
 
     def human_percentage(self):
-        if self.progress_count is not None and self.total is not None:
+        if self.progress_count is not None and self.total:
             return percentage(num=self.progress_count, total=self.total)
     human_percentage.short_description = _('percentage')
 

--- a/huey_monitor_project/tests/test_huey_monitor_models.py
+++ b/huey_monitor_project/tests/test_huey_monitor_models.py
@@ -1,0 +1,12 @@
+from django.test import TestCase
+from model_bakery import baker
+
+from huey_monitor.models import TaskModel
+
+
+class HueyMonitorModelsTestCase(TestCase):
+    def test_human_percentage(self):
+        instance = baker.make(TaskModel, progress_count=10, total=None)
+        self.assertIs(instance.human_percentage(), None)
+        instance.total = 100
+        self.assertEqual(instance.human_percentage(), '10%')


### PR DESCRIPTION
e.g.:
```
  File ".../site-packages/huey_monitor/models.py", line 124, in human_percentage
    return percentage(num=self.progress_count, total=self.total)
  File ".../site-packages/huey_monitor/humanize.py", line 51, in percentage
    frac = num / total

Exception Type: ZeroDivisionError at /admin/huey_monitor/taskmodel/
Exception Value: division by zero
```