### PR TITLE
Improved display of TaskModel hierarchy in TaskModelAdmin object page

### DIFF
--- a/huey_monitor/admin.py
+++ b/huey_monitor/admin.py
@@ -63,6 +63,7 @@ class TaskModelAdmin(FixLookupAllowedMixin, admin.ModelAdmin):
     def get_changelist(self, request, **kwargs):
         return TaskModelChangeList
 
+    @admin.display(description=_('Execution detail'))
     def column_name(self, obj):
         qs = obj.sub_tasks.all()
         context = {
@@ -77,18 +78,14 @@ class TaskModelAdmin(FixLookupAllowedMixin, admin.ModelAdmin):
     column_name.short_description = _('Task name')
 
     def task_hierarchy_info(self, obj):
+        qs = TaskModel.objects.filter(parent_task_id=obj.pk)
+        context = {
+            'sub_tasks': qs
+        }
         if obj.parent_task_id is not None:
             # This is a sub task
-            context = {
-                'main_task': TaskModel.objects.get(pk=obj.parent_task_id),
-            }
-        else:
-            # This is a main Task
-            qs = TaskModel.objects.filter(parent_task_id=obj.pk)
-            context = {
-                'sub_tasks': qs,
-            }
-
+            context['main_task'] = TaskModel.objects.get(pk=obj.parent_task_id)
+            
         return render_to_string(
             template_name='admin/huey_monitor/taskmodel/task_hierarchy_info.html',
             context=context,

--- a/huey_monitor/templates/admin/huey_monitor/taskmodel/task_hierarchy_info.html
+++ b/huey_monitor/templates/admin/huey_monitor/taskmodel/task_hierarchy_info.html
@@ -1,12 +1,18 @@
 {% load i18n humanize_time %}
 
 {% if main_task %}
+<p>Parent task: </p>
 <p>
     <a href="{{ main_task.admin_link }}">{% firstof main_task.desc main_task.name %}</a>
     {{ main_task.state|default_if_none:"" }}
     {{ main_task.human_progress_string }}
 </p>
-{% elif sub_tasks %}
+{% else %}
+    <p>This task has no parent task.</p>
+{% endif %}
+<br>
+{% if sub_tasks %}
+    <p>This task has {{sub_tasks|length}} sub tasks:</p>
     <table class="table-bordered table-condensed table-striped huey_monitor">
     <thead>
         <tr>


### PR DESCRIPTION
This adds the possibility to see for each task if it has parent and children tasks
My sub tasks often have subtasks, and with the current version of the admin, I'm pretty blind

No big changes, no impact on testing... 
not depending on anything else
Working for some time now on my server

I think it is ready to make it to the official repository