### PR TITLE
preventing ZeroDivisionError in throughput

### DIFF
--- a/huey_monitor/humanize.py
+++ b/huey_monitor/humanize.py
@@ -75,7 +75,8 @@ def throughput(num, elapsed_sec, suffix='', divisor=1000) -> str:
         if suffix:
             return f'0/{suffix}'
         return '0'
-    rate = num / elapsed_sec
+    # need to prevent ZeroDivisionError:
+    rate = num / max(elapsed_sec, 0.001)
 
     if rate > 1:
         rate_str = format_sizeof(rate, suffix=suffix, divisor=divisor)


### PR DESCRIPTION
I just spent almost one week trying to figure out the origin of a seamingly random error which afected my code ...

sometime, the difference between execute_dt and update_dt was so small that dividing by the difference led to a ZeroDivisionError when displaying the task name in task log...

stupid and difficult to spot error corrected through this PR