### PR TITLE
Update Huey: v2.5.2 -> v2.5.3

### DIFF
--- a/huey_monitor_project/tests/test_huey_monitor.py
+++ b/huey_monitor_project/tests/test_huey_monitor.py
@@ -25,10 +25,14 @@ class HueyMonitorTestCase(HtmlAssertionMixin, TestCase):
         signals = list(
             SignalInfoModel.objects.order_by('create_dt').values_list('task_id', 'signal_name', 'exception_line')
         )
-        assert signals == [
-            (task_model_instance.pk, 'executing', ''),
-            (task_model_instance.pk, 'complete', ''),
-        ]
+        self.assertEqual(
+            signals,
+            [
+                (task_model_instance.pk, 'enqueued', ''),
+                (task_model_instance.pk, 'executing', ''),
+                (task_model_instance.pk, 'complete', ''),
+            ],
+        )
 
         assert task_model_instance.state.signal_name == 'complete'
         url = f'/admin/huey_monitor/taskmodel/{task_model_instance.pk}/change/'
@@ -62,10 +66,14 @@ class HueyMonitorTestCase(HtmlAssertionMixin, TestCase):
         assert TaskModel.objects.count() == 1
 
         signals = list(SignalInfoModel.objects.order_by('create_dt').values_list('signal_name', 'exception_line'))
-        assert signals == [
-            ('executing', ''),
-            ('error', 'This is a test exception'),
-        ]
+        self.assertEqual(
+            signals,
+            [
+                ('enqueued', ''),
+                ('executing', ''),
+                ('error', 'This is a test exception'),
+            ],
+        )
 
         error_signal = SignalInfoModel.objects.get(signal_name='error')
         url = f'/admin/huey_monitor/signalinfomodel/{error_signal.pk}/change/'

--- a/huey_monitor_project/tests/test_tqdm.py
+++ b/huey_monitor_project/tests/test_tqdm.py
@@ -33,7 +33,7 @@ class SleepMock:
         instance = TaskModel.objects.all().first()
 
         executing_dt = instance.executing_dt
-        assert executing_dt == parse_dt('2000-01-01T00:00:02+0000')
+        assert executing_dt == parse_dt('2000-01-01T00:00:04+0000'), f'{executing_dt.isoformat()=}'
 
         self.progress_info.append([self.count, instance.elapsed_sec, str(instance)])
 
@@ -51,7 +51,7 @@ class ProcessInfoTestCase(TestCase):
             linear_processing_task(desc='Foo Bar', total=10)
 
         signals = list(SignalInfoModel.objects.values_list('signal_name', flat=True))
-        assert signals == ['executing', 'complete']
+        self.assertEqual(signals, ['enqueued', 'executing', 'complete'])
 
         # Add the last entry, executed after time.sleep() so not captured, yet:
         sleep_mock.add_iteration()
@@ -130,8 +130,8 @@ class ProcessInfoTestCase(TestCase):
         main_task_id = task_result.task.id
 
         main_task_instance = TaskModel.objects.get(pk=main_task_id)
-        assert main_task_instance.human_progress_string() == ('10/10it 100% 2.5 seconds/it finished')
-        assert str(main_task_instance) == ('parallel_task: 10/10it 100% 2.5 seconds/it finished (Main task)')
+        self.assertEqual(main_task_instance.human_progress_string(), '10/10it 100% 2.9 seconds/it finished')
+        assert str(main_task_instance) == ('parallel_task: 10/10it 100% 2.9 seconds/it finished (Main task)')
 
         sub_tasks = TaskModel.objects.filter(parent_task=main_task_instance).order_by('update_dt')
         values = list(sub_tasks.values_list('name', 'state__signal_name'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
-    "huey!=2.5.3",  # https://github.com/coleifer/huey
+    "huey",  # https://github.com/coleifer/huey
     "django",
     "bx_py_utils",  # https://github.com/boxine/bx_py_utils
     "bx_django_utils",  # https://github.com/boxine/bx_django_utils

--- a/uv.lock
+++ b/uv.lock
@@ -637,7 +637,7 @@ requires-dist = [
     { name = "bx-django-utils" },
     { name = "bx-py-utils" },
     { name = "django" },
-    { name = "huey", specifier = "!=2.5.3" },
+    { name = "huey" },
 ]
 
 [package.metadata.requires-dev]
@@ -937,9 +937,9 @@ wheels = [
 
 [[package]]
 name = "huey"
-version = "2.5.2"
+version = "2.5.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/fe/2e063984cdd512aa71e9c9c2a9200b58a830c532d25ca2c6cbc8e44bf7b7/huey-2.5.2.tar.gz", hash = "sha256:df33db474c05414ed40ee2110e9df692369871734da22d74ffb035a4bd74047f", size = 889357, upload-time = "2024-09-25T18:03:33.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/8c/2dfecf3705f5e522097b4e9fb6fb38e627a0340f8362cc05bd7a845e4279/huey-2.5.3.tar.gz", hash = "sha256:089fc72b97fd26a513f15b09925c56fad6abe4a699a1f0e902170b37e85163c7", size = 836918, upload-time = "2025-03-19T14:46:51.614Z" }
 
 [[package]]
 name = "icdiff"


### PR DESCRIPTION
The new signal `enqueued` was added, see: https://github.com/coleifer/huey/releases/tag/2.5.3

This results also in changed mocked time ticks.